### PR TITLE
Ignore large files from history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+Atlases/*
+Datasets/*


### PR DESCRIPTION
To keep git history lean ignoring example datasets would be a good practice. 

If you need to push changes for files from these directories:

```
git add --force my/ignore/file.foo
```

Congrats for your toolbox, happy to see you on GH :) 